### PR TITLE
Fix for potential invalid Lua code generation in `moonly::bundler::add_text_file(const std::filesystem::path& file)`.

### DIFF
--- a/include/moonly/bundler.hpp
+++ b/include/moonly/bundler.hpp
@@ -69,6 +69,7 @@ private:
   void unindent(std::size_t level = 1) noexcept;
 
   void print_file(const std::string& data);
+  void print_file_writing(const std::string& content);
   void new_line() noexcept;
 
   void print_no_indent(const std::string& text) {

--- a/src/moonly/bundler.cpp
+++ b/src/moonly/bundler.cpp
@@ -204,11 +204,7 @@ void bundler::add_text_file(const std::filesystem::path& file) noexcept {
   unindent(2);
   print("end");
   new_line();
-
-  print("file:write([[");
-  print_no_indent(text);
-  print_no_indent("]])");
-
+  print_file_writing(text);
   new_line();
   print("file:flush()");
   new_line();
@@ -339,6 +335,41 @@ void bundler::print_file(const std::string& data) {
     print(line);
     new_line();
   }
+}
+
+void bundler::print_file_writing(const std::string& content) {
+  std::size_t length            = content.length();
+  std::size_t long_string_level = 0;
+  std::size_t index             = 0;
+
+  while (index < length) {
+    if (content[index] != ']') {
+      index++;
+      continue;
+    }
+
+    std::size_t new_long_string_level = 1;
+
+    index++;
+
+    while (index < length && content[index] == '=') {
+      new_long_string_level++;
+      index++;
+    }
+
+    if (index > length || content[index] != ']' ||
+        new_long_string_level < long_string_level) {
+      continue;
+    }
+
+    long_string_level = new_long_string_level;
+  }
+
+  auto long_string_level_str = std::string(long_string_level, '=');
+
+  print("file:write([{}[", long_string_level_str);
+  print_no_indent(content);
+  print_no_indent("]{}])", long_string_level_str);
 }
 
 void bundler::new_line() noexcept {

--- a/src/moonly/utility.cpp
+++ b/src/moonly/utility.cpp
@@ -1,5 +1,6 @@
 #include <moonly/utility.hpp>
 
+#include <algorithm>
 #include <array>
 #include <fstream>
 
@@ -61,9 +62,9 @@ auto utility::read_file_as_binary(const fs::path& path) noexcept
   std::vector<std::vector<std::uint8_t>> chunks;
 
   while (file.tellg() < size) {
-    size_t bytes_to_read =
-        std::min(kChunkSize,
-                 static_cast<size_t>(size) - static_cast<size_t>(file.tellg()));
+    size_t bytes_to_read = std::min<decltype(kChunkSize)>(
+        kChunkSize,
+        static_cast<size_t>(size) - static_cast<size_t>(file.tellg()));
     file.read(reinterpret_cast<char*>(buffer.data()), bytes_to_read);
     if (!file) {
       break;


### PR DESCRIPTION
Currently, if the file passed in the `std::filesystem::path const& file` is containing the `]]` (double-square-bracket) symbols, then it would break the execution of the produced Lua script.

This pull request resolves this issue by searching for the `]< =* >?]` pattern in the file content and outputting the long string with an increased nesting level (level + 1) in `file:write(...)`. For example (the syntax is correct for Lua 5.1+):

```lua
-- File content: [[ hello ]]. Output:
file:write([=[[[ hello ]]]=])
-- File content: [=[ hello ]=]. Output:
file:write([==[[=[ hello ]=]]==])
```

Additionally, this pull request resolves compilation issues when compiling with the `g++ (GCC) 15.2.1 20260103` compiler. Currently, it produces the following error messages:

```bash
[dzone@archlinux moonly-command-tool]$ cmake --build build/
[ 20%] Built target zip
[ 30%] Building CXX object CMakeFiles/moonly.dir/src/moonly/utility.cpp.o
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp: In static member function 'static std::vector<std::vector<unsigned char> > moonly::utility::read_file_as_binary(const std::filesystem::__cxx11::path&)':
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp:65:17: error: no matching function for call to 'min(const long long unsigned int&, size_t)'
   65 |         std::min(kChunkSize,
      |         ~~~~~~~~^~~~~~~~~~~~
   66 |                  static_cast<size_t>(size) - static_cast<size_t>(file.tellg()));
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp:65:17: note: there are 4 candidates
In file included from /usr/include/c++/15.2.1/string:53,
                 from /home/dzone/dev/moonly-command-tool/include/moonly/utility.hpp:3,
                 from /home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp:1:
/usr/include/c++/15.2.1/bits/stl_algobase.h:234:5: note: candidate 1: 'template<class _Tp> constexpr const _Tp& std::min(const _Tp&, const _Tp&)'
  234 |     min(const _Tp& __a, const _Tp& __b)
      |     ^~~
/usr/include/c++/15.2.1/bits/stl_algobase.h:234:5: note: template argument deduction/substitution failed:
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp:65:17: note:   deduced conflicting types for parameter 'const _Tp' ('long long unsigned int' and 'size_t' {aka 'long unsigned int'})
   65 |         std::min(kChunkSize,
      |         ~~~~~~~~^~~~~~~~~~~~
   66 |                  static_cast<size_t>(size) - static_cast<size_t>(file.tellg()));
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/stl_algobase.h:282:5: note: candidate 2: 'template<class _Tp, class _Compare> constexpr const _Tp& std::min(const _Tp&, const _Tp&, _Compare)'
  282 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/usr/include/c++/15.2.1/bits/stl_algobase.h:282:5: note: candidate expects 3 arguments, 2 provided
In file included from /usr/include/c++/15.2.1/bits/unicode.h:39,
                 from /usr/include/c++/15.2.1/format:61,
                 from /usr/include/c++/15.2.1/ostream:44,
                 from /usr/include/c++/15.2.1/istream:43,
                 from /usr/include/c++/15.2.1/sstream:42,
                 from /usr/include/c++/15.2.1/bits/quoted_string.h:40,
                 from /usr/include/c++/15.2.1/iomanip:55,
                 from /usr/include/c++/15.2.1/bits/fs_path.h:38,
                 from /usr/include/c++/15.2.1/filesystem:54,
                 from /home/dzone/dev/moonly-command-tool/include/moonly/utility.hpp:4:
/usr/include/c++/15.2.1/bits/stl_algo.h:5764:5: note: candidate 3: 'template<class _Tp> constexpr _Tp std::min(initializer_list<_Tp>)'
 5764 |     min(initializer_list<_Tp> __l)
      |     ^~~
/usr/include/c++/15.2.1/bits/stl_algo.h:5764:5: note: candidate expects 1 argument, 2 provided
/usr/include/c++/15.2.1/bits/stl_algo.h:5774:5: note: candidate 4: 'template<class _Tp, class _Compare> constexpr _Tp std::min(initializer_list<_Tp>, _Compare)'
 5774 |     min(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
/usr/include/c++/15.2.1/bits/stl_algo.h:5774:5: note: template argument deduction/substitution failed:
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp:65:17: note:   mismatched types 'std::initializer_list<_Tp>' and 'long long unsigned int'
   65 |         std::min(kChunkSize,
      |         ~~~~~~~~^~~~~~~~~~~~
   66 |                  static_cast<size_t>(size) - static_cast<size_t>(file.tellg()));
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp: In static member function 'static bool moonly::utility::is_text_file(const std::filesystem::__cxx11::path&)':
/home/dzone/dev/moonly-command-tool/src/moonly/utility.cpp:131:23: error: 'any_of' is not a member of 'std::ranges'; did you mean 'std::any_of'?
  131 |   return std::ranges::any_of(text_extensions, [&](const auto& text_ext) {
      |                       ^~~~~~
/usr/include/c++/15.2.1/bits/stl_algo.h:449:5: note: 'std::any_of' declared here
  449 |     any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
      |     ^~~~~~
make[2]: *** [CMakeFiles/moonly.dir/build.make:163: CMakeFiles/moonly.dir/src/moonly/utility.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:236: CMakeFiles/moonly.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```